### PR TITLE
fix docker args generation on build

### DIFF
--- a/docker-args-build
+++ b/docker-args-build
@@ -1,1 +1,0 @@
-docker-args-deploy


### PR DESCRIPTION
Hey,

on rebuilding / deployment I ran into this error:

```+ DOCKER_ARGS=' --link dokku.beanstalkd.<app_name>:BEANSTALKD --env BEANSTALKD_URL=beanstalkd://IP:11300/'
- docker build --link dokku.beanstalkd.<app_name>:BEANSTALKD --env BEANSTALKD_URL=beanstalkd://IP:11300/ -t dokku/<app_name>:latest .
  flag provided but not defined: --link
  See 'docker build --help'.```

`docker build` doesn't accept `--link` and `--env` arguments, so I guess we don't need to run the `docker-args-deploy` script on build. What do you think about this? Ever ran into the same error?

I removed the symlink and now rebuilding seems to work fine. Would be great to have some feedback on that, because I'm not sure if I'm missing something. :)

Cheers
